### PR TITLE
serverside配下のmultimodule化を実装

### DIFF
--- a/serverside/api/build.gradle.kts
+++ b/serverside/api/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    kotlin("plugin.spring")
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+}
+
+dependencies {
+    implementation(project(":openapi-generator"))
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    runtimeOnly("org.postgresql:postgresql")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.5")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}

--- a/serverside/api/src/main/kotlin/com/personal/shisan/ShisanDashboardApplication.kt
+++ b/serverside/api/src/main/kotlin/com/personal/shisan/ShisanDashboardApplication.kt
@@ -1,0 +1,11 @@
+package com.personal.shisan
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class ShisanDashboardApplication
+
+fun main(args: Array<String>) {
+	runApplication<ShisanDashboardApplication>(*args)
+}

--- a/serverside/api/src/main/kotlin/com/personal/shisan/interfaces/controllers/UserController.kt
+++ b/serverside/api/src/main/kotlin/com/personal/shisan/interfaces/controllers/UserController.kt
@@ -1,0 +1,17 @@
+package com.personal.shisan.interfaces.controllers
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("users")
+class UserController {
+    @GetMapping("/{id}/")
+    fun showUsers(@PathVariable("id") userId : String): String {
+        println("this isunsafe")
+        println(userId)
+        return "index"
+    }
+}

--- a/serverside/api/src/main/resources/application.yml
+++ b/serverside/api/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/shisan
+    username: postgres
+    password: postgres
+    driver-class-name: org.postgresql.Driver
+
+mybatis:
+  mapper-locations: classpath*:mappers/*.xml
+  type-aliases-package: com.personal.shisan.domain
+
+logging:
+  level:
+    com.personal.shisan: DEBUG

--- a/serverside/api/src/test/kotlin/com/personal/keiba/ShisanDashboardApplicationTests.kt
+++ b/serverside/api/src/test/kotlin/com/personal/keiba/ShisanDashboardApplicationTests.kt
@@ -1,0 +1,13 @@
+package com.personal.keiba
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class ShisanDashboardApplicationTests {
+
+	@Test
+	fun contextLoads() {
+	}
+
+}

--- a/serverside/build.gradle.kts
+++ b/serverside/build.gradle.kts
@@ -1,41 +1,36 @@
 plugins {
-	kotlin("jvm") version "1.9.25"
-	kotlin("plugin.spring") version "1.9.25"
-	id("org.springframework.boot") version "3.5.5-SNAPSHOT"
-	id("io.spring.dependency-management") version "1.1.7"
+	kotlin("jvm") version "1.9.25" apply false
+	kotlin("plugin.spring") version "1.9.25" apply false
+	id("org.springframework.boot") version "3.5.5-SNAPSHOT" apply false
+	id("io.spring.dependency-management") version "1.1.7" apply false
 }
 
-group = "com.personal"
-version = "0.0.1-SNAPSHOT"
-
-java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+allprojects {
+	group = "com.personal"
+	version = "0.0.1-SNAPSHOT"
+	
+	repositories {
+		mavenCentral()
+		maven { url = uri("https://repo.spring.io/snapshot") }
 	}
 }
 
-repositories {
-	mavenCentral()
-	maven { url = uri("https://repo.spring.io/snapshot") }
-}
+subprojects {
+	apply(plugin = "org.jetbrains.kotlin.jvm")
 
-dependencies {
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5")
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    runtimeOnly("org.postgresql:postgresql")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-	testImplementation("org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.5")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-}
-
-kotlin {
-	compilerOptions {
-		freeCompilerArgs.addAll("-Xjsr305=strict")
+	java {
+		toolchain {
+			languageVersion = JavaLanguageVersion.of(21)
+		}
 	}
-}
 
-tasks.withType<Test> {
-	useJUnitPlatform()
+	kotlin {
+		compilerOptions {
+			freeCompilerArgs.addAll("-Xjsr305=strict")
+		}
+	}
+
+	tasks.withType<Test> {
+		useJUnitPlatform()
+	}
 }

--- a/serverside/openapi-generator/build.gradle.kts
+++ b/serverside/openapi-generator/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    id("org.openapi.generator") version "7.10.0"
+}
+
+openApiGenerate {
+    generatorName.set("kotlin-spring")
+    inputSpec.set("$rootDir/../docs/swagger/root.yml")
+    outputDir.set("$buildDir/generated")
+    apiPackage.set("com.personal.shisan.generated.api")
+    modelPackage.set("com.personal.shisan.generated.model")
+    configOptions.set(mapOf(
+        "dateLibrary" to "java8",
+        "interfaceOnly" to "true",
+        "useTags" to "true",
+        "serializationLibrary" to "jackson"
+    ))
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir("$buildDir/generated/src/main/kotlin")
+        }
+    }
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+}
+
+tasks.named("compileKotlin") {
+    dependsOn("openApiGenerate")
+}

--- a/serverside/settings.gradle.kts
+++ b/serverside/settings.gradle.kts
@@ -5,3 +5,6 @@ pluginManagement {
 	}
 }
 rootProject.name = "shisan api"
+
+include("openapi-generator")
+include("api")


### PR DESCRIPTION
serverside配下を単一モジュールからmultimodule構成に変更し、OpenAPI Generatorを統合しました。

## 変更内容
- `settings.gradle.kts`にopenapi-generatorとapiモジュールを追加
- ルート`build.gradle.kts`をmultimodule用に再構成
- openapi-generatorモジュールを作成（OpenAPI Generator plugin設定）
- apiモジュールを作成し既存コードを移行

## 動作確認
- `./gradlew openApiGenerate`: OpenAPI定義からコード生成
- `./gradlew :api:bootRun`: API起動

Closes #1

Generated with [Claude Code](https://claude.ai/code)